### PR TITLE
Updating sql for no geom column

### DIFF
--- a/etc/confd/templates/tegola.toml.tmpl
+++ b/etc/confd/templates/tegola.toml.tmpl
@@ -26,11 +26,11 @@ max_connections = 100        # The max connections to maintain in the connection
   sql = '''
       SELECT
         MAX(gid) as gid,
-        ST_AsBinary(ST_Collect(geom)) AS geom,
+        ST_AsBinary(ST_Collect(seg.geom)) AS geom,
         trip_count,
         bin_num
-      FROM hashed_trips ht
-      WHERE !HASH! AND geom && !BBOX!
+      FROM hashed_trips ht, geos_trips_segs as seg
+      WHERE !HASH! AND ht.gid = seg.id AND geom && !BBOX!
       GROUP BY hash, {{getv "/tegola/providers/layers/field2"}}, bin_num
   '''
   hash_fieldname = "hash"


### PR DESCRIPTION
## Goal ##
Related to https://github.com/Billups/demos/pull/83
This is a change to account for the new trips method that doesn't fill in the geom column. We will also need to remove the geom column for the SQL to properly work

## Test ##
With the geom column removed from the `hashed_trips` table the trips should still be returned correctly. If the geom column is not removed then the calls start failing. Therefore the geom column will need to be removed at the same time this is rolled out.