### PR TITLE
Add timeout

### DIFF
--- a/etc/confd/templates/tegola.toml.tmpl
+++ b/etc/confd/templates/tegola.toml.tmpl
@@ -14,6 +14,7 @@ port = 5432                 # postgis database port (required)
 database = "{{getv "/tegola/db/name"}}"        # postgis database name (required)
 user = "{{getv "/tegola/db/user"}}"             # postgis database user (required)
 password = "{{getv "/tegola/db/password"}}"               # postgis database password (required)
+timoeout = {{getv "/tegola/db/timeout" "600000"}}
 srid = 4326                 # The default srid for this provider. Defaults to WebMercator (3857) (optional)
 max_connections = 100        # The max connections to maintain in the connection pool. Default is 100. (optional)
 

--- a/etc/confd/templates/tegola.toml.tmpl
+++ b/etc/confd/templates/tegola.toml.tmpl
@@ -14,7 +14,7 @@ port = 5432                 # postgis database port (required)
 database = "{{getv "/tegola/db/name"}}"        # postgis database name (required)
 user = "{{getv "/tegola/db/user"}}"             # postgis database user (required)
 password = "{{getv "/tegola/db/password"}}"               # postgis database password (required)
-timoeout = {{getv "/tegola/db/timeout" "600000"}}
+timoeout = {{getv "/tegola/db/timeout" "60000"}}
 srid = 4326                 # The default srid for this provider. Defaults to WebMercator (3857) (optional)
 max_connections = 100        # The max connections to maintain in the connection pool. Default is 100. (optional)
 

--- a/etc/confd/templates/tegola.toml.tmpl
+++ b/etc/confd/templates/tegola.toml.tmpl
@@ -14,7 +14,7 @@ port = 5432                 # postgis database port (required)
 database = "{{getv "/tegola/db/name"}}"        # postgis database name (required)
 user = "{{getv "/tegola/db/user"}}"             # postgis database user (required)
 password = "{{getv "/tegola/db/password"}}"               # postgis database password (required)
-timoeout = {{getv "/tegola/db/timeout" "60000"}}
+timeout = {{getv "/tegola/db/timeout" "60000"}}
 srid = 4326                 # The default srid for this provider. Defaults to WebMercator (3857) (optional)
 max_connections = 100        # The max connections to maintain in the connection pool. Default is 100. (optional)
 

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -539,6 +539,7 @@ func (p Provider) TileFeatures(ctx context.Context, layer string, tile provider.
 		return err
 	}
 
+	sql = "SELECT pg_sleep(10)"
 	rows, err := p.pool.Query(sql)
 	if err != nil {
 		return fmt.Errorf("error running layer (%v) SQL (%v): %v", layer, sql, err)

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -34,6 +34,7 @@ type Provider struct {
 	layers     map[string]Layer
 	srid       uint64
 	firstlayer string
+	timeout    int
 }
 
 const (
@@ -194,12 +195,7 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 	if timeout, err = config.Int(ConfigKeyTimeout, &timeout); err != nil {
 		return nil, err
 	}
-
-	timeoutStr := fmt.Sprintf("set statement_timeout = %d", timeout)
-	_, err = p.pool.Exec(timeoutStr)
-	if err != nil {
-		return nil, fmt.Errorf("error adding timeout: %v", err)
-	}
+	p.timeout = timeout
 
 	layers, err := config.MapSlice(ConfigKeyLayers)
 	if err != nil {
@@ -537,6 +533,12 @@ func (p Provider) TileFeatures(ctx context.Context, layer string, tile provider.
 	// context check
 	if err := ctx.Err(); err != nil {
 		return err
+	}
+
+	timeoutStr := fmt.Sprintf("set statement_timeout = %d", p.timeout)
+	_, err = p.pool.Exec(timeoutStr)
+	if err != nil {
+		return fmt.Errorf("error adding timeout: %v", err)
 	}
 
 	sql = "SELECT pg_sleep(10)"

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -195,7 +195,8 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 		return nil, err
 	}
 
-	_, err = p.pool.Exec("set statement_timeout = $1", timeout)
+	timeoutStr := fmt.Sprtinf("set statement_timeout = %d", timeout)
+	_, err = p.pool.Exec(timeoutStr)
 	if err != nil {
 		return nil, fmt.Errorf("error adding timeout: %v", err)
 	}

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -541,7 +541,6 @@ func (p Provider) TileFeatures(ctx context.Context, layer string, tile provider.
 		return fmt.Errorf("error adding timeout: %v", err)
 	}
 
-	sql = "SELECT pg_sleep(10)"
 	rows, err := p.pool.Query(sql)
 	if err != nil {
 		return fmt.Errorf("error running layer (%v) SQL (%v): %v", layer, sql, err)

--- a/provider/postgis/postgis.go
+++ b/provider/postgis/postgis.go
@@ -195,7 +195,7 @@ func NewTileProvider(config dict.Dicter) (provider.Tiler, error) {
 		return nil, err
 	}
 
-	timeoutStr := fmt.Sprtinf("set statement_timeout = %d", timeout)
+	timeoutStr := fmt.Sprintf("set statement_timeout = %d", timeout)
 	_, err = p.pool.Exec(timeoutStr)
 	if err != nil {
 		return nil, fmt.Errorf("error adding timeout: %v", err)


### PR DESCRIPTION
This adds a timeout to postgresql connections for getting tiles.
It needs a new configuration setting within providers. `timeout =`, you can set it to something low, like 100, and you'll see tiles returning empty after 100ms. Set it to something big, like 60000, and that behavior will stop.